### PR TITLE
Update command: add option to remove unused

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ Then you can update your translation files (`.po`) using the `stonejs update` co
 The available options are:
 
 * `--quiet`, `-q`: do not output progress log to stdout
-* `--remove-unused`: remove from translation files (`.po`) messages that are not present in the source translation template (`.pot`)
+* `--remove-obsolete`: remove from translation files (`.po`) messages that are not present in the source translation template (`.pot`)
 
-Example:
+Examples:
 
     stonejs update locales/*.po locales/catalog.pot
 
-    stonejs update --remove-unused locales/*.po locales/catalog.pot
+    stonejs update --remove-obsolete locales/*.po locales/catalog.pot
 
 
 ## Building Translations

--- a/README.md
+++ b/README.md
@@ -82,10 +82,13 @@ Then you can update your translation files (`.po`) using the `stonejs update` co
 The available options are:
 
 * `--quiet`, `-q`: do not output progress log to stdout
+* `--remove-unused`: remove from translation files (`.po`) messages that are not present in the source translation template (`.pot`)
 
 Example:
 
-    stonejs locales/*.po locales/catalog.pot
+    stonejs update locales/*.po locales/catalog.pot
+
+    stonejs update --remove-unused locales/*.po locales/catalog.pot
 
 
 ## Building Translations

--- a/src/update.js
+++ b/src/update.js
@@ -23,7 +23,7 @@ var update = {};
  *
  *     {
  *         'quiet': false   // If true: do not output logs
- *         'remove-unused': false // If true: remove messages in .po files that are not in template .pot
+ *         'remove-obsolete': false // If true: remove messages in .po files that are not in template .pot
  *     }
  *
  * @method main
@@ -120,7 +120,7 @@ update.updatePo = function(poData, potData, options) {
         }
     }
 
-    if (options["remove-unused"]) {
+    if (options["remove-obsolete"]) {
         for (msgctxt in po.translations) {
             if (pot.translations[msgctxt] === undefined) {
                 delete po.translations[msgctxt];

--- a/src/update.js
+++ b/src/update.js
@@ -23,13 +23,14 @@ var update = {};
  *
  *     {
  *         'quiet': false   // If true: do not output logs
+ *         'removeUnused': false // If true: remove messages in .po files that are not in template .pot
  *     }
  *
  * @method main
  * @static
  * @param {Array} poFiles the .po files to update (can contain glob pattern)
  * @param {String} template the .pot file
- * @param {Object} options additional options (optional, default: see above)
+ * @param {Object} [options] additional options (optional, default: see above)
  * @param {Function} callback function called when everything is done (optional)
  */
 update.main = function(poFiles, template, options, callback) {
@@ -62,7 +63,7 @@ update.main = function(poFiles, template, options, callback) {
                     helpers.warn("    /!\\ Skipped!", options);
                     continue;
                 }
-                poData = update.updatePo(poData, potData);
+                poData = update.updatePo(poData, potData, options);
                 fs.writeFileSync(files[i], poData, {encoding: "utf-8"});
             }
             callback();
@@ -77,17 +78,21 @@ update.main = function(poFiles, template, options, callback) {
  * @static
  * @param {String} poData the po file content
  * @param {String} potData the pot file content
+ * @param {Object} [options] additional options (optional, default: see above)
  * @return {String} the update po data
  */
-update.updatePo = function(poData, potData) {
+update.updatePo = function(poData, potData, options) {
+    options = options || {};
     var pot = gettextParser.po.parse(potData);
     var po = gettextParser.po.parse(poData);
 
     po.headers["po-revision-date"] = helpers.dateFormat(new Date());
     var nplural = helpers.nplurals(po.headers["plural-forms"]);
+    var msgctxt;
+    var msgid;
 
-    for (var msgctxt in pot.translations) {
-        for (var msgid in pot.translations[msgctxt]) {
+    for (msgctxt in pot.translations) {
+        for (msgid in pot.translations[msgctxt]) {
             if (msgid === "") continue;
             if (po.translations[msgctxt] === undefined) {
                 po.translations[msgctxt] = {};
@@ -110,6 +115,20 @@ update.updatePo = function(poData, potData) {
                         msgstr.push(po.translations[msgctxt][msgid].msgstr[i] || "");
                     }
                     po.translations[msgctxt][msgid].msgstr = msgstr;
+                }
+            }
+        }
+    }
+
+    if (options.removeUnused) {
+        for (msgctxt in po.translations) {
+            if (pot.translations[msgctxt] === undefined) {
+                delete po.translations[msgctxt];
+                continue;
+            }
+            for (msgid in po.translations[msgctxt]) {
+                if (pot.translations[msgctxt][msgid] === undefined) {
+                    delete po.translations[msgctxt][msgid];
                 }
             }
         }

--- a/src/update.js
+++ b/src/update.js
@@ -23,7 +23,7 @@ var update = {};
  *
  *     {
  *         'quiet': false   // If true: do not output logs
- *         'removeUnused': false // If true: remove messages in .po files that are not in template .pot
+ *         'remove-unused': false // If true: remove messages in .po files that are not in template .pot
  *     }
  *
  * @method main
@@ -120,7 +120,7 @@ update.updatePo = function(poData, potData, options) {
         }
     }
 
-    if (options.removeUnused) {
+    if (options["remove-unused"]) {
         for (msgctxt in po.translations) {
             if (pot.translations[msgctxt] === undefined) {
                 delete po.translations[msgctxt];

--- a/test/updateSpec.js
+++ b/test/updateSpec.js
@@ -21,8 +21,16 @@ describe("stonejs update:", function() {
                     .and.to.contain('msgid "translatable 5"')
                     .and.to.contain('msgid "escaped @ 7"')
                     .and.to.contain('msgid "duplicated"');
-                    //.and.to.contain('#~ msgid "removed 1"')
-                    //.and.not.to.contain('msgid "removed 1"');
+            });
+
+            describe("update with option to remove unused messaged", function() {
+                expect(update.updatePo(poData, potData, { removeUnused: true }))
+                    .to.contain('msgstr "traductible 1"')
+                    .and.to.contain('msgid "translatable 5"')
+                    .and.to.contain('msgid "escaped @ 7"')
+                    .and.to.contain('msgid "duplicated"')
+                    .and.not.to.contain('#~ msgid "removed 1"')
+                    .and.not.to.contain('msgid "removed 1"');
             });
         });
 
@@ -97,8 +105,20 @@ describe("stonejs update:", function() {
                     .and.to.contain('msgid "translatable 5"')
                     .and.to.contain('msgid "escaped @ 7"')
                     .and.to.contain('msgid "duplicated"');
-                    //.and.to.contain('#~ msgid "removed 1"')
-                    //.and.not.to.contain('msgid "removed 1"');
+                done();
+            });
+        });
+
+        it("updates po file from a pot, with option to remove unused", function(done) {
+            update.main([outputPoFile], potFile, { quiet: true, removeUnused: true }, function() {
+                var poData = fs.readFileSync(outputPoFile).toString();
+                expect(poData)
+                    .to.contain('msgstr "traductible 1"')
+                    .and.to.contain('msgid "translatable 5"')
+                    .and.to.contain('msgid "escaped @ 7"')
+                    .and.to.contain('msgid "duplicated"')
+                    .and.not.to.contain('#~ msgid "removed 1"')
+                    .and.not.to.contain('msgid "removed 1"');
                 done();
             });
         });

--- a/test/updateSpec.js
+++ b/test/updateSpec.js
@@ -24,7 +24,7 @@ describe("stonejs update:", function() {
             });
 
             describe("update with option to remove unused messaged", function() {
-                expect(update.updatePo(poData, potData, { "remove-unused": true }))
+                expect(update.updatePo(poData, potData, { "remove-obsolete": true }))
                     .to.contain('msgstr "traductible 1"')
                     .and.to.contain('msgid "translatable 5"')
                     .and.to.contain('msgid "escaped @ 7"')
@@ -110,7 +110,7 @@ describe("stonejs update:", function() {
         });
 
         it("updates po file from a pot, with option to remove unused", function(done) {
-            update.main([outputPoFile], potFile, { quiet: true, "remove-unused": true }, function() {
+            update.main([outputPoFile], potFile, { quiet: true, "remove-obsolete": true }, function() {
                 var poData = fs.readFileSync(outputPoFile).toString();
                 expect(poData)
                     .to.contain('msgstr "traductible 1"')

--- a/test/updateSpec.js
+++ b/test/updateSpec.js
@@ -24,7 +24,7 @@ describe("stonejs update:", function() {
             });
 
             describe("update with option to remove unused messaged", function() {
-                expect(update.updatePo(poData, potData, { removeUnused: true }))
+                expect(update.updatePo(poData, potData, { "remove-unused": true }))
                     .to.contain('msgstr "traductible 1"')
                     .and.to.contain('msgid "translatable 5"')
                     .and.to.contain('msgid "escaped @ 7"')
@@ -110,7 +110,7 @@ describe("stonejs update:", function() {
         });
 
         it("updates po file from a pot, with option to remove unused", function(done) {
-            update.main([outputPoFile], potFile, { quiet: true, removeUnused: true }, function() {
+            update.main([outputPoFile], potFile, { quiet: true, "remove-unused": true }, function() {
                 var poData = fs.readFileSync(outputPoFile).toString();
                 expect(poData)
                     .to.contain('msgstr "traductible 1"')

--- a/test/updateSpec.js
+++ b/test/updateSpec.js
@@ -23,7 +23,7 @@ describe("stonejs update:", function() {
                     .and.to.contain('msgid "duplicated"');
             });
 
-            describe("update with option to remove unused messaged", function() {
+            describe("update with option to remove obsolete messages", function() {
                 expect(update.updatePo(poData, potData, { "remove-obsolete": true }))
                     .to.contain('msgstr "traductible 1"')
                     .and.to.contain('msgid "translatable 5"')
@@ -109,7 +109,7 @@ describe("stonejs update:", function() {
             });
         });
 
-        it("updates po file from a pot, with option to remove unused", function(done) {
+        it("updates po file from a pot, with option to remove obsolete messages", function(done) {
             update.main([outputPoFile], potFile, { quiet: true, "remove-obsolete": true }, function() {
                 var poData = fs.readFileSync(outputPoFile).toString();
                 expect(poData)


### PR DESCRIPTION
Add option `--remove-unused` in `update` command to remove messages from .po files that are not present in .pot template